### PR TITLE
Added in writing out HO metrics to Influx DB

### DIFF
--- a/cmd/trafficsim/trafficsim.go
+++ b/cmd/trafficsim/trafficsim.go
@@ -62,6 +62,7 @@ func main() {
 	numRoutes := flag.Int("numRoutes", 3, "Number of routes")
 	stepDelayMs := flag.Int("stepDelayMs", 1000, "delay between steps on route")
 	maxUEs := flag.Int("maxUEsPerTower", 5, "Max num of UEs per tower")
+	influxDbAddr := flag.String("influxDbAddr", "", "Address of Influx DB instance e.g. ran-metrics:8086")
 
 	//lines 93-109 are implemented according to
 	// https://github.com/kubernetes/klog/blob/master/examples/coexist_glog/coexist_glog.go
@@ -141,7 +142,8 @@ func main() {
 		log.Fatal("Unable to load trafficsim ", err)
 		return
 	}
-	mgr.Run(mapLayoutParams, towerParams, locationParams, routesParams)
+
+	mgr.Run(mapLayoutParams, towerParams, locationParams, routesParams, *influxDbAddr)
 
 	if err = startServer(*caPath, *keyPath, *certPath); err != nil {
 		log.Fatal("Unable to start trafficsim ", err)

--- a/pkg/manager/influxdb.go
+++ b/pkg/manager/influxdb.go
@@ -1,0 +1,104 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// RansimulatorDb is the name of the database in Influx
+const RansimulatorDb = "ransimulator"
+const writeResource = "write"
+const queryResource = "query"
+
+func checkInfluxDbAvailable(influxDbAddr string) bool {
+	dbURL, err := url.ParseRequestURI(fmt.Sprintf("http://%s", influxDbAddr))
+	if err != nil {
+		log.Error("to parse Influx DB address %s. %s", influxDbAddr, err.Error())
+		return false
+	}
+	dbURL.Path = queryResource
+
+	data := url.Values{}
+	data.Set("q", "SHOW DATABASES")
+
+	req, err := http.NewRequest("POST", dbURL.String(), strings.NewReader(data.Encode()))
+	if err != nil {
+		log.Error("Unable to form Influx DB request with %s. %s", influxDbAddr, err.Error())
+		return false
+	}
+
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("User-Agent", "ran-simulator")
+	req.Header.Add("Cache-Control", "no-cache")
+	req.Header.Add("Content-Length", strconv.Itoa(len(data.Encode())))
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Errorf("Error on Influx DB request with %s. %s", influxDbAddr, err.Error())
+		return false
+	}
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		log.Errorf("Error on Influx DB result with %s. %s", influxDbAddr, err.Error())
+		return false
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		log.Errorf("Expecting status code %d. Got %d. %s", 200, res.StatusCode, body)
+		return false
+	}
+	if strings.Contains(string(body), RansimulatorDb) {
+		return true
+	}
+	return false
+}
+
+// WriteHoMetricToInfluxDb writes out to the Influx dB - can be called from a go routine
+func WriteHoMetricToInfluxDb(influxDbAddr string, ueName string, latency int64, time int64) {
+	dbURL, err := url.ParseRequestURI(fmt.Sprintf("http://%s", influxDbAddr))
+	if err != nil {
+		log.Error("to parse Influx DB address %s. %s", influxDbAddr, err.Error())
+	}
+	dbURL.Path = writeResource
+	dbURL.RawQuery = "db=" + RansimulatorDb
+	data := fmt.Sprintf("hometrics,ue=%s value=%d %d", ueName, latency, time)
+	log.Infof("Writing %s to %s", dbURL.String(), data)
+	req, err := http.NewRequest("POST", dbURL.String(), strings.NewReader(data))
+	if err != nil {
+		log.Error("Unable to form Influx DB request with %s. %s", influxDbAddr, err.Error())
+	}
+
+	req.Header.Add("User-Agent", "ran-simulator")
+	req.Header.Add("Cache-Control", "no-cache")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Errorf("Error on Influx DB request with %s. %s", influxDbAddr, err.Error())
+	}
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		log.Errorf("Error on Influx DB result with %s. %s", influxDbAddr, err.Error())
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 204 {
+		log.Errorf("Expecting status code %d. Got %d. %s", 204, res.StatusCode, body)
+	}
+}

--- a/pkg/northbound/e2/metrics.go
+++ b/pkg/northbound/e2/metrics.go
@@ -49,6 +49,9 @@ func UpdateControlMetrics(in *e2.ControlResponse) {
 		ue := trafficSimMgr.UserEquipments[crntiToName(m.Crnti)]
 		if ue.Metrics.HoReportTimestamp != 0 {
 			ue.Metrics.HoLatency = time.Now().UnixNano() - ue.Metrics.HoReportTimestamp
+			if trafficSimMgr.InfluxDbAvail {
+				go manager.WriteHoMetricToInfluxDb(trafficSimMgr.InfluxDbAddr, m.Crnti, ue.Metrics.HoLatency, ue.Metrics.HoReportTimestamp)
+			}
 			ue.Metrics.HoReportTimestamp = 0
 			log.Infof("Hand-over latency: %d microsec", ue.Metrics.HoLatency/1000)
 		}


### PR DESCRIPTION
We can decide whether was want to write to Influx or Prometheus

I've run this and it gives me results like below

@shadansari can you check the logic - I'm storing nano seconds here but 
by the size of the values I think it's giving me the time between one Handover and the next?
```
> select * from hometrics
name: hometrics
time                ue   value
----                --   -----
1582752180362138167 0002 19867311202
1582752191734577056 0003 8495671580
1582752203738104212 0003 6004582628
1582752212740280125 0003 30011140674
1582752222742724243 0002 5005277715
1582752230745235400 0002 6007639481
1582752242748850121 0002 28013498195
1582752245749589281 0003 6005106746
1582752256752712680 0003 14015883288
1582752273756924345 0002 6003596911
1582752277757665966 0003 8013503360
1582752282758821480 0002 3003231959
1582752286759982643 0002 7003387807
1582752297762598905 0002 3004596287
1582752324462654227 0003 71819915744
1582752324663216226 0002 71618597969
1582752336191261981 0001 85018323743
1582752397203661381 0002 5002690943
1582752397203666076 0003 8003288407
1582752407205527437 0002 12003670754
1582752408205733786 0003 8002725060
1582752443211599405 0003 1517689
1582752444211747122 0002 1728930
1582752444211751529 0003 9003814717
1582752446212163177 0002 2001838110
1582752451212834702 0001 1517060
1582752451212840367 0002 8008786688
1582752455213530378 0001 2001981965
1582752457213867306 0003 20015395971
1582752459214287198 0001 8003704608
1582752460214486366 0002 1961985
1582752463215043493 0002 11004693078
1582752476217751746 0002 1001791690
1582752481218840706 0002 2002314485

```