### PR TITLE
Added exporting of Latency metric as Prometheus histogram

### DIFF
--- a/cmd/trafficsim/trafficsim.go
+++ b/cmd/trafficsim/trafficsim.go
@@ -62,6 +62,7 @@ func main() {
 	numRoutes := flag.Int("numRoutes", 3, "Number of routes")
 	stepDelayMs := flag.Int("stepDelayMs", 1000, "delay between steps on route")
 	maxUEs := flag.Int("maxUEsPerTower", 5, "Max num of UEs per tower")
+	metricsPort := flag.Int("metricsPort", 9090, "port for Prometheus metrics")
 
 	//lines 93-109 are implemented according to
 	// https://github.com/kubernetes/klog/blob/master/examples/coexist_glog/coexist_glog.go
@@ -141,7 +142,7 @@ func main() {
 		log.Fatal("Unable to load trafficsim ", err)
 		return
 	}
-	mgr.Run(mapLayoutParams, towerParams, locationParams, routesParams)
+	mgr.Run(mapLayoutParams, towerParams, locationParams, routesParams, *metricsPort)
 
 	if err = startServer(*caPath, *keyPath, *certPath); err != nil {
 		log.Fatal("Unable to start trafficsim ", err)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/onosproject/onos-config v0.0.0-20200224142543-b4e126cec9df // indirect
 	github.com/onosproject/onos-lib-go v0.0.0-20200220193455-fe7dac6f40c0
+	github.com/prometheus/client_golang v0.9.4
 	github.com/sergi/go-diff v1.1.0 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/grpc v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,7 @@ github.com/atomix/go-local v0.0.0-20200211010611-c99e53e4c653/go.mod h1:N3oigYZ/
 github.com/atomix/kubernetes-controller v0.0.0-20200124024416-04b783c4ede4/go.mod h1:6Jz1WZ379QpUynR5+7WoSC1/pCIn+yDxopSOV2Lmjas=
 github.com/atomix/kubernetes-controller v0.0.0-20200202101151-b31765af9a0f/go.mod h1:ud/7iiSYTsZ6mrzCMTpfMnUT6wCx9e/9tHavM7ZMYWA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -233,6 +234,7 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/mattn/goveralls v0.0.5/go.mod h1:Xg2LHi51faXLyKXwsndxiW6uxEEQT9+3sjGzzwU4xy0=
+github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -302,15 +304,19 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
+github.com/prometheus/client_golang v0.9.4 h1:Y8E/JaaPbmFSW2V81Ab/d8yZFYQQGbni1b1jPcG9Y6A=
 github.com/prometheus/client_golang v0.9.4/go.mod h1:oCXIBxdI62A4cR6aTRJCgetEjecSIYzOEaeAn4iYEpM=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
+github.com/prometheus/common v0.4.1 h1:K0MGApIoQvMw27RTdJkPbr3JZ7DNbtxQNyi5STVM6Kw=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.2 h1:6LJUbpNm42llc4HRCuvApCSWB/WfhuNo9K98Q9sNGfs=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/pkg/northbound/e2/metrics.go
+++ b/pkg/northbound/e2/metrics.go
@@ -62,6 +62,7 @@ func UpdateControlMetrics(in *e2.ControlResponse) {
 		if ue.Metrics.HoReportTimestamp != 0 {
 			ue.Metrics.HoLatency = time.Now().UnixNano() - ue.Metrics.HoReportTimestamp
 			ue.Metrics.HoReportTimestamp = 0
+			trafficSimMgr.LatencyChannel <- ue.Metrics.HoLatency
 			log.Infof("%s Hand-over latency: %d microsec", ue.Name, ue.Metrics.HoLatency/1000)
 		}
 	}

--- a/pkg/northbound/metrics/exporter.go
+++ b/pkg/northbound/metrics/exporter.go
@@ -1,0 +1,51 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"fmt"
+	liblog "github.com/onosproject/onos-lib-go/pkg/logging"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"net/http"
+)
+
+var log = liblog.GetLogger("northbound", "trafficsim")
+
+// RunHOExposer runs Prometheus exposer
+func RunHOExposer(port int, latencyChan chan int64) {
+	log.Infof("Starting Prometheus agent on http://:%d/metrics", port)
+	hoLatencyHistogram := prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "onosproject",
+			Subsystem: "ransimulator",
+			Name:      "hometrics",
+			Help:      "time (µs) from when RadioMeasReportUE is sent to when Handover is complete",
+			Buckets:   prometheus.ExponentialBuckets(1e3, 1.5, 20),
+		},
+	)
+	prometheus.MustRegister(hoLatencyHistogram)
+	go func() {
+		// block here until a latency measurement is received
+		for latency := range latencyChan {
+			hoLatencyHistogram.Observe(float64(latency / 1e3))
+		}
+	}()
+	http.Handle("/metrics", promhttp.Handler())
+	err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+	if err != nil {
+		log.Fatalf("error serving prometheus metrics %s", err.Error())
+	}
+}


### PR DESCRIPTION
With @shadansari bug fix the latency figures are now coming in in the low thousands of µs. Here's a sample of what I'm getting at
**http://ran-simulator:9090/metrics**
(only 1 below 2250 µs, only 2 above 11390 µs)
```
# TYPE onosproject_ransimulator_hometrics histogram
onosproject_ransimulator_hometrics_bucket{le="1000"} 0
onosproject_ransimulator_hometrics_bucket{le="1500"} 1
onosproject_ransimulator_hometrics_bucket{le="2250"} 7
onosproject_ransimulator_hometrics_bucket{le="3375"} 21
onosproject_ransimulator_hometrics_bucket{le="5062.5"} 36
onosproject_ransimulator_hometrics_bucket{le="7593.75"} 36
onosproject_ransimulator_hometrics_bucket{le="11390.625"} 36
onosproject_ransimulator_hometrics_bucket{le="17085.9375"} 38
onosproject_ransimulator_hometrics_bucket{le="25628.90625"} 38
onosproject_ransimulator_hometrics_bucket{le="38443.359375"} 38
onosproject_ransimulator_hometrics_bucket{le="+Inf"} 41
onosproject_ransimulator_hometrics_sum 2.5518247e+07
onosproject_ransimulator_hometrics_count 41
```