### PR TITLE
Fail on startup if the K8s Service API cannot be accessed for RBAC reasons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
     - $HOME/gopath/pkg/mod         # Cache the Go modules
 
 before_script:
-  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.19.1/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.6
 
 jobs:
   include:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,27 +1,47 @@
 # Ran Simulator
 
 The Ran Simulator is part of µONOS and is meant to work alongside `onos-ric` and
-`sd-ran-gui`.
+`onos-gui`.
 
 The simulator mimics a collection of Cell Towers and a set of UE's moving along
 routes between different locations.
 
-The application is very tunable through startup parameters, and can be run:
- 
-* as a standalone application in docker
-* deployed in a **Kubernetes** cluster
+The simulator has 2 main gRPC interfaces
+
+1. **trafficsim** - for communicating with the `onos-gui` - this is exposed on port `5150`
+1. **e2** - for communicating to `onos-ric` - there is a separate port opened per
+cell site (tower) starting at port `5152-`
+
+> The number of towers can be chosen at startup with the `-towerCols` and the `-towerRows`
+> arguments shown below. After startup the number of towers cannot be changed.
+
+As towers are created at startup, updates are made to:
+
+1. **onos-topo** - a `device` is added to `onos-topo` per cell site (tower), with
+an address including the cell-site port number.
+1. **Kubernetes API** - the `ran-simulator` service is expanded after startup with
+the port numbers added per cell site.
+
+> For the Kubernetes service to be manipulated like this, the 'update' RBAC permission
+> has to be given to the `ran-simulator` pod. This is done through the Helm Chart
+> as the role `ran-simulator-service-role` and the rolebinding `ran-simulator-access-services`
+
+The application is very tunable through startup parameters, and can be deployed
+only in a **Kubernetes** cluster. See [deployment](./deployment.md).
 
 ## Google Maps API Key
 The RAN Simulator can connect to Google's [Directions API] with a Google API Key.
 Google charges $5.00 per 1000 requests to the [Directions API], and so we do not put
-our API key up in the public domain. Without the API key directions will be created
-randomly between 2 locations (usually in the form of a zig-zag line).
+our API key up in the public domain.  
 
-The SD RAN GUI also (separately) accesses Google [Maps API] and incurs an additional
-cost of $7.00 per 1000 requests.
+> This feature will create Routes that follow known road and street layouts in the
+> real world and will make a better demo when used with `onos-gui`
+
+Without the API key Routes will be created randomly between 2 locations
+(usually in the form of a zig-zag line).
 
 ## Startup parameters
-Supplying `ran-simulator` with a bogus parameter gets it to show the start parameters
+Run `ran-simulator` with `-help` parameter to show the start parameters
 and their defaults
 ```bash
 docker run -it onosproject/ran-simulator:latest -help
@@ -70,10 +90,17 @@ Usage of /tmp/go-build089760012/b001/exe/trafficsim:
         The starting Zoom level (default 13)
 ```
 
+> Some of these only have an effect when the onos-gui MapView is active
+>
+> e.g. `fade` is used to control whether the map is displayed with full opacity or
+>faded at startup
+>
+> `-showRoutes`, `-showPower` and `-zoom` are also only related to the display
+
 See [deployment.md](deployment.md) for how to change these for a Kubernetes deployment.
 
 ## Browser access
-When deployed with the **sd-ran-gui** application, the simulation can be accessed
+When deployed with the **onos-gui** application, the simulation can be accessed
 from a browser.
 
 [Directions API]: https://developers.google.com/maps/documentation/directions/start

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -13,7 +13,8 @@ The RAN Simulator can connect to Google's [Directions API] and with a Google API
 Google charges $5.00 per 1000 requests to the [Directions API], and so we do not put
 our API key up in the public domain.
 
-> If a Google API key is not given, the simulator will revert to a built in random route generator
+> If a Google API key is not given OR is less than 38 chars in length, the simulator
+> will revert to the built in random route generator
 
 ## Tuning parameters
 [README.md](README.md) shows the list of startup parameters - these can be overridden using the
@@ -49,10 +50,10 @@ NAME         	NAMESPACE 	REVISION	UPDATED                                	STATUS
 onos-cli     	micro-onos	1       	2020-02-04 08:01:54.860813386 +0000 UTC	deployed	onos-cli-0.0.1     	1          
 onos-ric     	micro-onos	1       	2020-02-04 08:02:17.663782372 +0000 UTC	deployed	onos-ric-0.0.1     	1          
 ran-simulator	micro-onos	1       	2020-02-04 09:32:21.533299519 +0000 UTC	deployed	ran-simulator-0.0.1	1          
-sd-ran-gui   	micro-onos	1       	2020-02-04 09:32:49.018099586 +0000 UTC	deployed	sd-ran-gui-0.0.1   	1  
+onos-gui   	    micro-onos	1       	2020-02-04 09:32:49.018099586 +0000 UTC	deployed	onos-gui-0.0.1   	1  
 ```
 
-> Here the service is shown running alongside `onos-cli`, `onos-ric` and the `sd-ran-gui`
+> Here the service is shown running alongside `onos-cli`, `onos-ric` and the `onos-gui`
 > as these are usually deployed together to give a demo scenario. See the individual
 > deployment instructions for these services.
 
@@ -63,7 +64,7 @@ NAME                             READY   STATUS             RESTARTS   AGE
 onos-cli-68bbf4f674-ssjt4        1/1     Running            0          18m
 onos-ric-5fb8c6bdd7-xmcmq        1/1     Running            0          18m
 ran-simulator-6f577597d8-5lcv8   1/1     Running            0          82s
-sd-ran-gui-76ff54d85-fh72j       2/2     Running            0          54s
+onos-gui-76ff54d85-fh72j         2/2     Running            0          54s
 ```
 
 See Troubleshooting below if the `Status` is not `Running`
@@ -77,7 +78,7 @@ helm install -n <your_name_space> ran-simulator ran-simulator
 
 ### Troubleshoot
 If your chart does not install or the pod is not running for some reason and/or you modified values Helm offers two flags to help you
-debug your chart:  
+debug your chart:
 
 * `--dry-run` check the chart without actually installing the pod. 
 * `--debug` prints out more information about your chart
@@ -85,23 +86,6 @@ debug your chart:
 ```bash
 helm install -n micro-onos ran-simulator --debug --dry-run ran-simulator/
 ```
-
-#### CrashLoopBackOff
-If the ran-simulator has a status of `CrashLoopBackOff` it is usually an indication
-that the Google API Key is not valid. Un-deploy the ran-simulator, update the key
-in `values.yaml` and redeploy it again.
-
-Looking at the logs of the pod shows where this is the case
-```bash
-> kubectl -n micro-onos logs ran-simulator-6f65c8b57-rq4gf
-E0204 08:24:24.305652       1 trafficsim.go:69] Cant' avoid double Error logging no such flag -alsologtostderr
-I0204 08:24:24.305777       1 trafficsim.go:111] Starting trafficsim
-I0204 08:24:24.305804       1 manager.go:40] Creating Manager
-I0204 08:24:24.305818       1 manager.go:51] Starting Manager with {3 3 0.02 0.02} {10} {3 YOUR_API_KEY_HERE 1s}
-I0204 08:24:24.305953       1 dispatcher.go:41] User Equipment Event listener initialized
-I0204 08:24:24.306070       1 dispatcher.go:79] Route Event listener initialized
-F0204 08:24:24.553960       1 manager.go:62] Error calculating routes maps: REQUEST_DENIED - The provided API key is invalid.
-``` 
 
 ## Uninstalling the chart.
 

--- a/pkg/southbound/kubernetes/kubernetes.go
+++ b/pkg/southbound/kubernetes/kubernetes.go
@@ -57,9 +57,8 @@ func AddK8SServicePorts(rangeStart int32, rangeEnd int32) {
 		log.Errorf("Service %s not found in namespace %s", serviceName, namespace)
 		return
 	} else if statusError, isStatus := err.(*errors.StatusError); isStatus {
-		log.Errorf("Error getting Service %s in namespace %s. Status: %v",
+		log.Fatal("Error getting Service %s in namespace %s. Status: %v",
 			serviceName, namespace, statusError.ErrStatus.Message)
-		return
 	} else if err != nil {
 		log.Fatalf("Kubernetes API error %s", err.Error())
 	}


### PR DESCRIPTION
Also updated the documentation to refer to `onos-gui` instead of `sd-ran-gui`

Also updated travis version of golangci-lint