### PR TITLE
Add an option to not export all HO events

### DIFF
--- a/cmd/trafficsim/trafficsim.go
+++ b/cmd/trafficsim/trafficsim.go
@@ -66,6 +66,7 @@ func main() {
 	stepDelayMs := flag.Int("stepDelayMs", 1000, "delay between steps on route")
 	maxUEsPerTower := flag.Int("maxUEsPerTower", 5, "Max num of UEs per tower")
 	metricsPort := flag.Int("metricsPort", 9090, "port for Prometheus metrics")
+	metricsAllHoEvents := flag.Bool("metricsAllHoEvents", true, "Export all HO events in metrics (only historgram if false)")
 	topoEndpoint := flag.String("topoEndpoint", "onos-topo:5150", "Endpoint for the onos-topo service")
 
 	//lines 93-109 are implemented according to
@@ -164,13 +165,18 @@ func main() {
 	rangeEnd := rangeStart + *towerCols**towerRows
 	kubernetes.AddK8SServicePorts(int32(rangeStart), int32(rangeEnd))
 
+	metricsParams := manager.MetricsParams{
+		Port:              *metricsPort,
+		ExportAllHOEvents: *metricsAllHoEvents,
+	}
+
 	log.Info("Starting trafficsim")
 	mgr, err := manager.NewManager()
 	if err != nil {
 		log.Fatal("Unable to load trafficsim ", err)
 		return
 	}
-	mgr.Run(mapLayoutParams, towerParams, routesParams, *topoEndpoint, *metricsPort, serverParams)
+	mgr.Run(mapLayoutParams, towerParams, routesParams, *topoEndpoint, *metricsPort, serverParams, metricsParams)
 
 	if err = startServer(*caPath, *keyPath, *certPath); err != nil {
 		log.Fatal("Unable to start trafficsim ", err)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -51,6 +51,12 @@ type Manager struct {
 	TopoClient         device.DeviceServiceClient
 }
 
+// MetricsParams for the Prometheus exporter
+type MetricsParams struct {
+	Port              int
+	ExportAllHOEvents bool
+}
+
 // NewManager initializes the RAN subsystem.
 func NewManager() (*Manager, error) {
 	log.Info("Creating Manager")
@@ -69,7 +75,8 @@ func NewManager() (*Manager, error) {
 
 // Run starts a synchronizer based on the devices and the northbound services.
 func (m *Manager) Run(mapLayoutParams types.MapLayout, towerparams types.TowersParams,
-	routesParams RoutesParams, topoEndpoint string, metricsPort int, serverParams utils.ServerParams) {
+	routesParams RoutesParams, topoEndpoint string, metricsPort int, serverParams utils.ServerParams,
+	metricsParams MetricsParams) {
 	log.Infof("Starting Manager with %v %v %v", mapLayoutParams, towerparams, routesParams)
 	m.MapLayout = mapLayoutParams
 	m.TowersLock.Lock()
@@ -93,7 +100,7 @@ func (m *Manager) Run(mapLayoutParams types.MapLayout, towerparams types.TowersP
 
 	go m.startMoving(routesParams)
 
-	go metrics.RunHOExposer(metricsPort, m.LatencyChannel)
+	go metrics.RunHOExposer(metricsParams.Port, m.LatencyChannel, metricsParams.ExportAllHOEvents)
 
 	ctx := context.Background()
 	m.TopoClient = topo.ConnectToTopo(ctx, topoEndpoint, serverParams)


### PR DESCRIPTION
Starting the ran-simulator like:
```
helm -n micro-onos install ran-simulator ran-simulator --set metricsAllHoEvents=false
```
will disable the exporting of all of the HO events to Prometheus.

It is left at "true" by default for the moment.

Exporting **all** events is a big performance hit on the ran-simulator and is unnecessary for performance measurement. 

The "histogram" approach that remains is sufficient to understand the delays - the delay values are bucketed locally and can displayed on Grafana as a Heatmap if we need to see its progress over time.

The Prometheus QL for the histogram is `onosproject_ransimulator_hometrics_bucket`

There will be a corresponding Helm Chart update for this