### PR TITLE
Graceful shutdown of simulator - Fixes #108

### DIFF
--- a/pkg/manager/userequipment.go
+++ b/pkg/manager/userequipment.go
@@ -96,11 +96,7 @@ func (m *Manager) SetNumberUes(numUes int) error {
 	m.UserEquipmentsMapLock.Lock()
 	defer m.UserEquipmentsMapLock.Unlock()
 	currentNum := len(m.UserEquipments)
-	if numUes < int(m.MapLayout.MinUes) {
-		return fmt.Errorf("number of UEs requested %d is below minimum %d", numUes, m.MapLayout.MinUes)
-	} else if numUes > int(m.MapLayout.MaxUes) {
-		return fmt.Errorf("number of UEs requested %d is above maximum %d", numUes, m.MapLayout.MaxUes)
-	} else if numUes < currentNum {
+	if numUes < currentNum {
 		log.Infof("Decreasing number of UEs from %d to %d", currentNum, numUes)
 		for ueidx := currentNum - 1; ueidx >= numUes; ueidx-- {
 			imsi := utils.ImsiGenerator(ueidx)

--- a/pkg/northbound/e2/control_test.go
+++ b/pkg/northbound/e2/control_test.go
@@ -63,6 +63,5 @@ func Test_HandleRrmConfig(t *testing.T) {
 
 	handleRRMConfig(&testReq)
 	time.Sleep(time.Millisecond * 110)
-
-	mgr.Close()
+	stopManager(mgr)
 }

--- a/pkg/northbound/e2/e2_test.go
+++ b/pkg/northbound/e2/e2_test.go
@@ -60,3 +60,21 @@ func setUpManager() (*manager.Manager, error) {
 	}
 	return mgr, nil
 }
+
+func stopManager(m *manager.Manager) {
+	close(m.CellsChannel)
+	close(m.UeChannel)
+	close(m.RouteChannel)
+	close(m.LatencyChannel)
+	for r := range m.Routes {
+		delete(m.Routes, r)
+	}
+	for l := range m.Locations {
+		delete(m.Locations, l)
+	}
+	m.CellsLock.Lock()
+	for tid := range m.Cells {
+		delete(m.Cells, tid)
+	}
+	m.CellsLock.Unlock()
+}

--- a/pkg/northbound/e2/telemetry_test.go
+++ b/pkg/northbound/e2/telemetry_test.go
@@ -50,6 +50,5 @@ func Test_GenerateReport(t *testing.T) {
 			t.Errorf("Unexpected Ecid %s in report", ecid)
 		}
 	}
-
-	mgr.Close()
+	stopManager(mgr)
 }

--- a/pkg/northbound/trafficsim/trafficsim.go
+++ b/pkg/northbound/trafficsim/trafficsim.go
@@ -218,12 +218,22 @@ func (s *Server) ListUes(req *trafficsim.ListUesRequest, stream trafficsim.Traff
 // SetNumberUEs - change the number of UEs in the simulation
 // Cannot be set below the minimum or above the maximum
 func (s *Server) SetNumberUEs(ctx context.Context, req *trafficsim.SetNumberUEsRequest) (*trafficsim.SetNumberUEsResponse, error) {
-	numRoutes := req.GetNumber()
-	err := manager.GetManager().SetNumberUes(int(numRoutes))
+	numUes := req.GetNumber()
+	minUes := manager.GetManager().MapLayout.MinUes
+	maxUes := manager.GetManager().MapLayout.MaxUes
+	if numUes < minUes {
+		return nil, status.Errorf(codes.OutOfRange,
+			"number of UEs requested %d is below minimum %d", numUes, minUes)
+	} else if numUes > maxUes {
+		return nil, status.Errorf(codes.OutOfRange,
+			"number of UEs requested %d is above maximum %d", numUes, maxUes)
+	}
+
+	err := manager.GetManager().SetNumberUes(int(numUes))
 	if err != nil {
 		return nil, status.Error(codes.OutOfRange, err.Error())
 	}
-	return &trafficsim.SetNumberUEsResponse{Number: numRoutes}, nil
+	return &trafficsim.SetNumberUEsResponse{Number: numUes}, nil
 }
 
 // ResetMetrics resets the metrics on demand

--- a/pkg/southbound/topo/topo.go
+++ b/pkg/southbound/topo/topo.go
@@ -71,6 +71,21 @@ func SyncToTopo(ctx context.Context, topoClient *topodevice.DeviceServiceClient,
 	log.Infof("%d cell devices created on onos-topo", len(cells))
 }
 
+// RemoveFromTopo - on shutdown delete the cells from topo
+func RemoveFromTopo(ctx context.Context, topoClient *topodevice.DeviceServiceClient, cells map[types.ECGI]*types.Cell) {
+	for _, c := range cells {
+		topoDevice := &topodevice.Device{
+			ID: topodevice.ID(topoCellID(c.GetEcgi())),
+		}
+		_, err := (*topoClient).Remove(ctx, &topodevice.RemoveRequest{Device: topoDevice})
+		if err != nil {
+			log.Warnf("Could not remove %s to onos-topo %s", topoCellID(c.GetEcgi()), err.Error())
+			continue
+		}
+		log.Infof("Removed %s from topo", topoCellID(c.GetEcgi()))
+	}
+}
+
 // createCellForTopo -- prepare the cell to be added to onos-topo
 func createCellForTopo(cell *types.Cell) *topodevice.Device {
 	timeOut := time.Second * ranSimTimeoutSec


### PR DESCRIPTION
Removes all of the UEs, so that RIC will handle it correctly;

then removes the devices that it had added to topo on shutdown

this should clear up onos-ric whiuch will be notified about the deletions (need to test)