### PR TITLE
Ensure device NONE event is not ignored

### DIFF
--- a/pkg/manager/towers.go
+++ b/pkg/manager/towers.go
@@ -68,9 +68,18 @@ func CellCreator(device *topodevice.Device) error {
 	if err != nil {
 		return nil
 	}
-	log.Infof("Cell created %s", cell.Ecgi)
 
 	mgr := GetManager()
+
+	mgr.CellsLock.Lock()
+	defer mgr.CellsLock.Unlock()
+
+	if _, ok := mgr.Cells[*cell.Ecgi]; ok {
+		return nil
+	}
+
+	log.Infof("Cell created %s", cell.Ecgi)
+
 	mgr.Cells[*cell.Ecgi] = cell
 	mgr.cellCreateTimer.Reset(time.Second)
 	// If no new cells have been created in the last second, then


### PR DESCRIPTION
Fixes race conditions to ensure device events are received and handled properly.

First, the connection was only configured with the unary retrying interceptor, so the list call was not being retried since it's a stream.

Second, the `NONE` type list response was being ignored since Go `switch` statements do not support fallthrough.