### PR TITLE
Rename `yaml:*` tags with `mapstructure:*` tags for Viper

### DIFF
--- a/pkg/api/trafficsim/trafficsim_test.go
+++ b/pkg/api/trafficsim/trafficsim_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/onosproject/ran-simulator/pkg/store/nodes"
 	"github.com/onosproject/ran-simulator/pkg/store/ues"
 	"io"
-	"io/ioutil"
 	"net"
 	"testing"
 
@@ -20,7 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
-	"gopkg.in/yaml.v2"
 )
 
 var lis *bufconn.Listener
@@ -31,13 +29,9 @@ func bufDialer(context.Context, string) (net.Conn, error) {
 
 func newTestService() (northbound.Service, error) {
 	m := &model.Model{}
-	bytes, err := ioutil.ReadFile("../../model/test.yaml")
+	err := model.LoadConfig(m, "../../model/test")
 	if err != nil {
-		return nil, err
-	}
-	err = yaml.Unmarshal(bytes, &m)
-	if err != nil {
-		return nil, err
+		return &Service{}, err
 	}
 	nodeStore := nodes.NewNodeRegistry(m.Nodes)
 	cellStore := cells.NewCellRegistry(m.Cells, nodeStore)

--- a/pkg/model/layout.go
+++ b/pkg/model/layout.go
@@ -6,10 +6,10 @@ package model
 
 // MapLayout represents information required for geo-map visualizations
 type MapLayout struct {
-	Center         Coordinate `yaml:"center"`
-	Zoom           float32    `yaml:"zoom"`
-	LocationsScale float32    `yaml:"locationsScale"`
-	FadeMap        bool       `yaml:"fade"`
-	ShowRoutes     bool       `yaml:"showRoutes"`
-	ShowPower      bool       `yaml:"showPower"`
+	Center         Coordinate `mapstructure:"center"`
+	Zoom           float32    `mapstructure:"zoom"`
+	LocationsScale float32    `mapstructure:"locationsScale"`
+	FadeMap        bool       `mapstructure:"fade"`
+	ShowRoutes     bool       `mapstructure:"showRoutes"`
+	ShowPower      bool       `mapstructure:"showPower"`
 }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -11,26 +11,26 @@ import (
 
 // Model simulation model
 type Model struct {
-	MapLayout     MapLayout               `yaml:"layout"`
-	Nodes         map[string]Node         `yaml:"nodes"`
-	Cells         map[string]Cell         `yaml:"cells"`
-	Controllers   map[string]Controller   `yaml:"controllers"`
-	ServiceModels map[string]ServiceModel `yaml:"servicemodels"`
-	UECount       uint                    `yaml:"ueCount"`
-	PlmnID        types.PlmnID            `yaml:"plmnID"`
+	MapLayout     MapLayout               `mapstructure:"layout"`
+	Nodes         map[string]Node         `mapstructure:"nodes"`
+	Cells         map[string]Cell         `mapstructure:"cells"`
+	Controllers   map[string]Controller   `mapstructure:"controllers"`
+	ServiceModels map[string]ServiceModel `mapstructure:"servicemodels"`
+	UECount       uint                    `mapstructure:"ueCount"`
+	PlmnID        types.PlmnID            `mapstructure:"plmnID"`
 }
 
 // Coordinate represents a geographical location
 type Coordinate struct {
-	Lat float64 `yaml:"lat"`
-	Lng float64 `yaml:"lng"`
+	Lat float64 `mapstructure:"lat"`
+	Lng float64 `mapstructure:"lng"`
 }
 
 // Sector represents a 2D arc emanating from a location
 type Sector struct {
-	Center  Coordinate `yaml:"center"`
-	Azimuth int32      `yaml:"azimuth"`
-	Arc     int32      `yaml:"arc"`
+	Center  Coordinate `mapstructure:"center"`
+	Azimuth int32      `mapstructure:"azimuth"`
+	Arc     int32      `mapstructure:"arc"`
 }
 
 // Route represents a named series of points for tracking movement of user-equipment
@@ -42,33 +42,31 @@ type Route struct {
 
 // Node e2 node
 type Node struct {
-	EnbID         types.EnbID  `yaml:"enbID"`
-	Controllers   []string     `yaml:"controllers"`
-	ServiceModels []string     `yaml:"servicemodels"`
-	Cells         []types.ECGI `yaml:"cells"`
-	Status        string       `yaml:"status"`
+	EnbID         types.EnbID  `mapstructure:"enbID"`
+	Controllers   []string     `mapstructure:"controllers"`
+	ServiceModels []string     `mapstructure:"servicemodels"`
+	Cells         []types.ECGI `mapstructure:"cells"`
+	Status        string       `mapstructure:"status"`
 }
 
 // Controller E2T endpoint information
 type Controller struct {
-	ID      string `yaml:"id"`
-	Address string `yaml:"address"`
-	Port    int    `yaml:"port"`
+	ID      string `mapstructure:"id"`
+	Address string `mapstructure:"address"`
+	Port    int    `mapstructure:"port"`
 }
 
 // Cell represents a section of coverage
 type Cell struct {
-	ECGI      types.ECGI   `yaml:"ecgi"`
-	Sector    Sector       `yaml:"sector"`
-	Color     string       `yaml:"color"`
-	MaxUEs    uint32       `yaml:"maxUEs"`
-	Neighbors []types.ECGI `yaml:"neighbors"`
-	TxPowerDB float64      `yaml:"txPower"`
-
-	// TODO: track tbhe following relationships differently via UERegistry
+	ECGI      types.ECGI   `mapstructure:"ecgi"`
+	Sector    Sector       `mapstructure:"sector"`
+	Color     string       `mapstructure:"color"`
+	MaxUEs    uint32       `mapstructure:"maxUEs"`
+	Neighbors []types.ECGI `mapstructure:"neighbors"`
+	TxPowerDB float64      `mapstructure:"txPower"`
 	//Crntis map
-	//CrntiIndex uint32     `yaml:"crntiIndex"`
-	//Port       uint32     `yaml:"port"`
+	//CrntiIndex uint32     `mapstructure:"crntiIndex"`
+	//Port       uint32     `mapstructure:"port"`
 }
 
 // UEType represents type of user-equipment
@@ -98,9 +96,9 @@ type UE struct {
 
 // ServiceModel service model information
 type ServiceModel struct {
-	ID          int    `yaml:"id"`
-	Description string `yaml:"description"`
-	Version     string `yaml:"version"`
+	ID          int    `mapstructure:"id"`
+	Description string `mapstructure:"description"`
+	Version     string `mapstructure:"version"`
 }
 
 // GetServiceModel gets a service model based on a given name.

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -5,19 +5,16 @@
 package model
 
 import (
-	"github.com/onosproject/ran-simulator/api/types"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
+
+	"github.com/onosproject/ran-simulator/api/types"
 )
 
 func TestModel(t *testing.T) {
-	model := Model{}
-	bytes, err := ioutil.ReadFile("test.yaml")
-	assert.NoError(t, err)
-	err = yaml.Unmarshal(bytes, &model)
+	model := &Model{}
+	err := LoadConfig(model, "test")
 	assert.NoError(t, err)
 	t.Log(model)
 	assert.Equal(t, 2, len(model.Controllers))

--- a/pkg/store/nodes/nodes_test.go
+++ b/pkg/store/nodes/nodes_test.go
@@ -7,18 +7,14 @@ package nodes
 import (
 	"github.com/onosproject/ran-simulator/api/types"
 	"github.com/onosproject/ran-simulator/pkg/model"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
 )
 
 func TestNodes(t *testing.T) {
-	m := model.Model{}
-	bytes, err := ioutil.ReadFile("../../model/test.yaml")
-	assert.NoError(t, err)
-	err = yaml.Unmarshal(bytes, &m)
+	m := &model.Model{}
+	err := model.LoadConfig(m, "../../model/test")
 	assert.NoError(t, err)
 	t.Log(m)
 


### PR DESCRIPTION
Viper doesn't interpret the yaml:* struct tags properly. Replace the
yaml tags with mapstructure tags.

Also some refactoring of load.go

Update model_test.go