### PR TITLE
Fix utils.InitialBearing to use radian

### DIFF
--- a/pkg/utils/geo.go
+++ b/pkg/utils/geo.go
@@ -49,7 +49,7 @@ func InitialBearing(c1 model.Coordinate, c2 model.Coordinate) float64 {
 	lo1 = c1.Lng * math.Pi / 180
 	la2 = c2.Lat * math.Pi / 180
 	lo2 = c2.Lng * math.Pi / 180
-	
+
 	y := math.Sin(lo2-lo1) * math.Cos(la2)
 	x := math.Cos(la1)*math.Sin(la2) - math.Sin(la1)*math.Cos(la2)*math.Cos(lo2-lo1)
 	theta := math.Atan2(y, x)


### PR DESCRIPTION
I found that UEs did not follow the generated route waypoints. The cause seems to be the calculation using degree units, not radians, in the `InitialBearing` function.